### PR TITLE
chore: bump scalingo provider from ~> 2.2 to ~> 2.7

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     scalingo = {
       source  = "scalingo/scalingo"
-      version = "~> 2.2"
+      version = "~> 2.7"
     }
 
     environment = {


### PR DESCRIPTION
## Summary
- Bump scalingo/scalingo provider version constraint from ~> 2.2 to ~> 2.7
- Required to access new features: project_id, hds_resource, letsencrypt_enabled, limited collaborators, base_url output

## Test plan
- [x] terraform init -backend=false && terraform validate passes