### PR TITLE
feat: support project_id to associate app with a Scalingo project

### DIFF
--- a/app.tf
+++ b/app.tf
@@ -5,6 +5,7 @@ data "scalingo_stack" "stack" {
 resource "scalingo_app" "app" {
   name = var.name
 
+  project_id  = var.project_id
   environment = var.environment
 
   stack_id    = data.scalingo_stack.stack.id

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "name" {
   type        = string
 }
 
+variable "project_id" {
+  description = "ID of the Scalingo project to associate the application with."
+  type        = string
+  default     = null
+}
+
 variable "stack" {
   description = "The stack to use for the app (default: \"scalingo-22\")."
   type        = string


### PR DESCRIPTION
## Summary
- Add optional project_id variable passed to scalingo_app resource
- Allows grouping applications into Scalingo projects (v2.5.0+)

## Test plan
- [x] terraform init -backend=false && terraform validate passes
- [ ] Verify project_id appears in terraform plan when set