### PR TITLE
feat: support hds_resource flag for health data hosting compliance

### DIFF
--- a/app.tf
+++ b/app.tf
@@ -12,6 +12,7 @@ resource "scalingo_app" "app" {
 
   sticky_session = var.sticky_session
   router_logs    = var.router_logs
+  hds_resource   = var.hds_resource
 
   lifecycle {
     precondition {

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,13 @@ variable "name" {
   type        = string
 }
 
+variable "hds_resource" {
+  description = "When true, the application is flagged as hosting health data (HDS compliance)."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
 variable "stack" {
   description = "The stack to use for the app (default: \"scalingo-22\")."
   type        = string


### PR DESCRIPTION
## Summary
- Add optional hds_resource boolean variable (default: false)
- Flags the application for HDS (Hebergeur de Donnees de Sante) compliance (v2.7.0+)
- Bumps provider to ~> 2.7

## Test plan
- [x] terraform init -backend=false && terraform validate passes