### PR TITLE
feat: support letsencrypt_enabled on canonical domain

### DIFF
--- a/domains.tf
+++ b/domains.tf
@@ -5,9 +5,7 @@ resource "scalingo_domain" "canonical_domain" {
   canonical   = true
   common_name = var.domain
 
-  # Attributes not supported by the provider on v2.2 :
-  # tlscert - optional: SSL Certificate you want to associate with the domain
-  # tlskey - optional: Private key used to create the SSL certificate
+  letsencrypt_enabled = var.letsencrypt
 }
 
 resource "scalingo_domain" "domain_aliases" {

--- a/variables.tf
+++ b/variables.tf
@@ -157,7 +157,7 @@ variable "addons" {
 # }
 
 variable "domain" {
-  description = "Main domain name of the application, known as \"canonical domain\" in Scalingo's dashboard. Note that SSL configuration must be completed through the dashboard."
+  description = "Main domain name of the application, known as \"canonical domain\" in Scalingo's dashboard."
   type        = string
   default     = null
   nullable    = true
@@ -166,6 +166,13 @@ variable "domain" {
     condition     = var.domain == null || can(length(regex("^([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,63})$", var.domain)) > 0)
     error_message = "The domain name must be a valid domain name."
   }
+}
+
+variable "letsencrypt" {
+  description = "Enable Let's Encrypt automatic TLS for the canonical domain. Set to false when using a custom certificate."
+  type        = bool
+  default     = true
+  nullable    = false
 }
 
 variable "domain_aliases" {


### PR DESCRIPTION
## Summary
- Add letsencrypt variable (default: true) to control automatic Let's Encrypt TLS on the canonical domain
- Replaces the outdated comment about unsupported TLS attributes in domains.tf
- Bumps provider to ~> 2.7

## Test plan
- [ ] terraform init -backend=false && terraform validate passes
- [ ] Setting letsencrypt = false disables automatic cert provisioning