### PR TITLE
feat: support limited (read-only) collaborators

### DIFF
--- a/collaborators.tf
+++ b/collaborators.tf
@@ -4,6 +4,9 @@ locals {
   masked_emails = {
     for email in var.additionnal_collaborators : base64sha256(email) => email
   }
+  masked_limited_emails = {
+    for email in var.limited_collaborators : base64sha256(email) => email
+  }
 }
 
 resource "scalingo_collaborator" "collaborators" {
@@ -11,4 +14,12 @@ resource "scalingo_collaborator" "collaborators" {
 
   app   = scalingo_app.app.id
   email = sensitive(each.value)
+}
+
+resource "scalingo_collaborator" "limited_collaborators" {
+  for_each = local.masked_limited_emails
+
+  app     = scalingo_app.app.id
+  email   = sensitive(each.value)
+  limited = true
 }

--- a/collaborators.tf
+++ b/collaborators.tf
@@ -22,4 +22,11 @@ resource "scalingo_collaborator" "limited_collaborators" {
   app     = scalingo_app.app.id
   email   = sensitive(each.value)
   limited = true
+
+  lifecycle {
+    precondition {
+      condition     = length(setintersection(toset(var.additionnal_collaborators), toset(var.limited_collaborators))) == 0
+      error_message = "An email cannot be listed in both additionnal_collaborators and limited_collaborators."
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,21 @@ variable "additionnal_collaborators" {
   }
 }
 
+variable "limited_collaborators" {
+  description = "List of emails of collaborators with limited (read-only) access to the application."
+  type        = list(string)
+  default     = []
+  nullable    = false
+
+  validation {
+    condition = length([
+      for email in var.limited_collaborators :
+      email if regex("^([a-zA-Z0-9_\\-\\.\\+]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,63})$", email) == false
+    ]) == 0
+    error_message = "The list of emails must contain only valid emails."
+  }
+}
+
 variable "environment" {
   description = "Map of environment variables to set on the application. Values must not be null or empty."
   type        = map(string)


### PR DESCRIPTION
## Summary
- Add limited_collaborators variable for collaborators with restricted (read-only) permissions
- Uses the same email masking pattern as existing additionnal_collaborators
- Non-breaking: new variable alongside the existing one

## Test plan
- [ ] terraform init -backend=false && terraform validate passes
- [ ] Adding an email to limited_collaborators creates a collaborator with limited = true