### PR TITLE
feat: implement notifiers and alerts

### DIFF
--- a/notifiers.tf
+++ b/notifiers.tf
@@ -1,0 +1,38 @@
+data "scalingo_notification_platform" "platforms" {
+  for_each = toset([for n in var.notifiers : n.platform])
+
+  name = each.value
+}
+
+resource "scalingo_notifier" "notifiers" {
+  for_each = { for n in var.notifiers : n.name => n }
+
+  app         = scalingo_app.app.id
+  name        = each.value.name
+  platform_id = data.scalingo_notification_platform.platforms[each.value.platform].id
+
+  active          = each.value.active
+  send_all_events = each.value.send_all_events
+  send_all_alerts = each.value.send_all_alerts
+  selected_events = each.value.selected_events
+  emails          = each.value.emails
+  webhook_url     = each.value.webhook_url
+}
+
+resource "scalingo_alert" "alerts" {
+  for_each = { for a in var.alerts : "${a.container_type}-${a.metric}" => a }
+
+  app            = scalingo_app.app.id
+  container_type = each.value.container_type
+  metric         = each.value.metric
+  limit          = each.value.limit
+
+  disabled                = each.value.disabled
+  duration_before_trigger = each.value.duration_before_trigger
+  remind_every            = each.value.remind_every
+  send_when_below         = each.value.send_when_below
+
+  notifiers = [
+    for name in each.value.notifiers : scalingo_notifier.notifiers[name].id
+  ]
+}

--- a/notifiers.tf
+++ b/notifiers.tf
@@ -32,7 +32,19 @@ resource "scalingo_alert" "alerts" {
   remind_every            = each.value.remind_every
   send_when_below         = each.value.send_when_below
 
+  # The conditional avoids a cryptic "invalid index" error when a name is
+  # unknown: the precondition below reports it with an explicit message.
   notifiers = [
-    for name in each.value.notifiers : scalingo_notifier.notifiers[name].id
+    for name in each.value.notifiers :
+    contains(keys(scalingo_notifier.notifiers), name) ? scalingo_notifier.notifiers[name].id : null
   ]
+
+  lifecycle {
+    precondition {
+      condition = alltrue([
+        for name in each.value.notifiers : contains([for n in var.notifiers : n.name], name)
+      ])
+      error_message = "Alert on ${each.value.container_type}/${each.value.metric} references a notifier name that does not exist in var.notifiers."
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -134,27 +134,53 @@ variable "addons" {
   nullable = false
 }
 
-# TODO: implement notifier and alert
-#
-# variable "notifications" {
-#   type = list(object({
-#     name            = string
-#     type            = string
-#     active          = optional(bool, true)
-#     emails          = optional(list(string), [])
-#     send_all_alerts = optional(bool, false)
-#     send_all_events = optional(bool, false)
-#     events          = optional(list(string), [])
-#     webhook_url     = optional(string, "")
-#     container_alerts = object({
-#       limit                   = optional(number, 0.8)
-#       metric                  = optional(string, "cpu")
-#       duration_before_trigger = optional(string)
-#     })
-#   }))
-#   default  = []
-#   nullable = false
-# }
+variable "notifiers" {
+  description = "List of notification channels (email, slack, webhook, rocket_chat) for the application."
+  type = list(object({
+    name            = string
+    platform        = string
+    active          = optional(bool, true)
+    send_all_events = optional(bool, false)
+    send_all_alerts = optional(bool, false)
+    selected_events = optional(set(string), [])
+    emails          = optional(list(string), [])
+    webhook_url     = optional(string, "")
+  }))
+  default  = []
+  nullable = false
+
+  validation {
+    condition = length([
+      for n in var.notifiers :
+      n if !contains(["email", "slack", "webhook", "rocket_chat"], n.platform)
+    ]) == 0
+    error_message = "Notifier platform must be one of: email, slack, webhook, rocket_chat."
+  }
+}
+
+variable "alerts" {
+  description = "List of metric-based alerts for the application containers."
+  type = list(object({
+    container_type          = string
+    metric                  = string
+    limit                   = number
+    disabled                = optional(bool, false)
+    duration_before_trigger = optional(string)
+    remind_every            = optional(string)
+    send_when_below         = optional(bool, false)
+    notifiers               = optional(list(string), [])
+  }))
+  default  = []
+  nullable = false
+
+  validation {
+    condition = length([
+      for a in var.alerts :
+      a if !contains(["cpu", "ram", "swap", "rpm"], a.metric)
+    ]) == 0
+    error_message = "Alert metric must be one of: cpu, ram, swap, rpm."
+  }
+}
 
 variable "domain" {
   description = "Main domain name of the application, known as \"canonical domain\" in Scalingo's dashboard. Note that SSL configuration must be completed through the dashboard."

--- a/variables.tf
+++ b/variables.tf
@@ -159,7 +159,7 @@ variable "notifiers" {
 }
 
 variable "alerts" {
-  description = "List of metric-based alerts for the application containers."
+  description = "List of metric-based alerts for the application containers. Only one alert per (container_type, metric) pair is supported. `duration_before_trigger` and `remind_every` are duration strings (e.g. \"5m\", \"1h\"). Each entry of `notifiers` must match the `name` of an entry in `var.notifiers`."
   type = list(object({
     container_type          = string
     metric                  = string
@@ -179,6 +179,13 @@ variable "alerts" {
       a if !contains(["cpu", "ram", "swap", "rpm"], a.metric)
     ]) == 0
     error_message = "Alert metric must be one of: cpu, ram, swap, rpm."
+  }
+
+  validation {
+    condition = length(var.alerts) == length(distinct([
+      for a in var.alerts : "${a.container_type}-${a.metric}"
+    ]))
+    error_message = "Only one alert per (container_type, metric) pair is supported."
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     scalingo = {
       source  = "scalingo/scalingo"
-      version = "~> 2.2"
+      version = "~> 2.7"
     }
 
     environment = {


### PR DESCRIPTION
## Summary
- Add notifiers variable to configure notification channels (email, slack, webhook, rocket_chat)
- Add alerts variable for metric-based container alerts (cpu, ram, swap, rpm)
- Alerts reference notifiers by name for automatic ID resolution
- Replaces the long-standing TODO comment in variables.tf
- New file: notifiers.tf

## Test plan
- [ ] terraform init -backend=false && terraform validate passes
- [ ] Notifier with platform = email resolves platform ID correctly
- [ ] Alert with notifiers = [my-notifier] links to the right notifier