### PR TITLE
docs: regenerate terraform-docs section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,24 @@ Used in production by :
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, < 2.0.0 |
 | <a name="requirement_environment"></a> [environment](#requirement\_environment) | ~> 1.3 |
-| <a name="requirement_scalingo"></a> [scalingo](#requirement\_scalingo) | ~> 2.2 |
+| <a name="requirement_scalingo"></a> [scalingo](#requirement\_scalingo) | ~> 2.7 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [scalingo_addon.addons](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/addon) | resource |
+| [scalingo_alert.alerts](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/alert) | resource |
 | [scalingo_app.app](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/app) | resource |
 | [scalingo_autoscaler.autoscalers](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/autoscaler) | resource |
 | [scalingo_collaborator.collaborators](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/collaborator) | resource |
+| [scalingo_collaborator.limited_collaborators](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/collaborator) | resource |
 | [scalingo_container_type.containers](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/container_type) | resource |
 | [scalingo_domain.canonical_domain](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/domain) | resource |
 | [scalingo_domain.domain_aliases](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/domain) | resource |
 | [scalingo_log_drain.addons](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/log_drain) | resource |
 | [scalingo_log_drain.app](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/log_drain) | resource |
+| [scalingo_notifier.notifiers](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/notifier) | resource |
 | [scalingo_scm_repo_link.scm_repo_link](https://registry.terraform.io/providers/scalingo/scalingo/latest/docs/resources/scm_repo_link) | resource |
 
 ## Inputs
@@ -71,15 +74,21 @@ Used in production by :
 |------|-------------|------|---------|:--------:|
 | <a name="input_additionnal_collaborators"></a> [additionnal\_collaborators](#input\_additionnal\_collaborators) | List of emails of collaborators that have admin rights for the application | `list(string)` | `[]` | no |
 | <a name="input_addons"></a> [addons](#input\_addons) | List of addons to add to the application | <pre>list(object({<br/>    provider          = string<br/>    plan              = string<br/>    database_features = optional(list(string))<br/>  }))</pre> | `[]` | no |
+| <a name="input_alerts"></a> [alerts](#input\_alerts) | List of metric-based alerts for the application containers. Only one alert per (container\_type, metric) pair is supported. `duration_before_trigger` and `remind_every` are duration strings (e.g. "5m", "1h"). Each entry of `notifiers` must match the `name` of an entry in `var.notifiers`. | <pre>list(object({<br/>    container_type          = string<br/>    metric                  = string<br/>    limit                   = number<br/>    disabled                = optional(bool, false)<br/>    duration_before_trigger = optional(string)<br/>    remind_every            = optional(string)<br/>    send_when_below         = optional(bool, false)<br/>    notifiers               = optional(list(string), [])<br/>  }))</pre> | `[]` | no |
 | <a name="input_authorize_unsecure_http"></a> [authorize\_unsecure\_http](#input\_authorize\_unsecure\_http) | When true, Scalingo does not automatically redirect HTTP traffic to HTTPS. The default behavior is to redirect HTTP traffic to HTTPS (when value is `false`) | `bool` | `false` | no |
 | <a name="input_containers"></a> [containers](#input\_containers) | Configuration of the containers of the application. | <pre>map(object({<br/>    size   = optional(string, "S")<br/>    amount = optional(number, 1)<br/>    autoscaler = optional(object({<br/>      min_containers = optional(number, 2)<br/>      max_containers = optional(number, 10)<br/>      metric         = optional(string, "cpu")<br/>      target         = optional(number, 0.8)<br/>    }))<br/>  }))</pre> | <pre>{<br/>  "web": {<br/>    "amount": 0,<br/>    "size": "S"<br/>  }<br/>}</pre> | no |
-| <a name="input_domain"></a> [domain](#input\_domain) | Main domain name of the application, known as "canonical domain" in Scalingo's dashboard. Note that SSL configuration must be completed through the dashboard. | `string` | `null` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | Main domain name of the application, known as "canonical domain" in Scalingo's dashboard. | `string` | `null` | no |
 | <a name="input_domain_aliases"></a> [domain\_aliases](#input\_domain\_aliases) | List of others domain names for the application | `list(string)` | `[]` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Map of environment variables to set on the application. Values must not be null or empty. | `map(string)` | `null` | no |
 | <a name="input_github_integration"></a> [github\_integration](#input\_github\_integration) | Configuration of the GitHub integration of the application. Only one of github\_integration or gitlab\_integration can be set. | <pre>object({<br/>    repo_url            = string<br/>    integration_uuid    = optional(string)<br/>    branch              = optional(string, "main")<br/>    auto_deploy_enabled = optional(bool, true)<br/>  })</pre> | `null` | no |
 | <a name="input_gitlab_integration"></a> [gitlab\_integration](#input\_gitlab\_integration) | Configuration of the GitLab integration of the application. Only one of github\_integration or gitlab\_integration can be set. | <pre>object({<br/>    repo_url            = string<br/>    integration_uuid    = optional(string)<br/>    branch              = optional(string, "main")<br/>    auto_deploy_enabled = optional(bool, true)<br/>  })</pre> | `null` | no |
+| <a name="input_hds_resource"></a> [hds\_resource](#input\_hds\_resource) | When true, the application is flagged as hosting health data (HDS compliance). | `bool` | `false` | no |
+| <a name="input_letsencrypt"></a> [letsencrypt](#input\_letsencrypt) | Enable Let's Encrypt automatic TLS for the canonical domain. Set to false when using a custom certificate. | `bool` | `true` | no |
+| <a name="input_limited_collaborators"></a> [limited\_collaborators](#input\_limited\_collaborators) | List of emails of collaborators with limited (read-only) access to the application. | `list(string)` | `[]` | no |
 | <a name="input_log_drains"></a> [log\_drains](#input\_log\_drains) | List of log\_drain configuration to redirect logs from the application and addons to a log management service. Each configuration is automatically associated to the application and to every eligible addons. | <pre>list(object({<br/>    type         = string<br/>    url          = optional(string, "")<br/>    drain_region = optional(string, "")<br/>    host         = optional(string, "")<br/>    port         = optional(string, "")<br/>    token        = optional(string, "")<br/>  }))</pre> | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the application. Must be unique on Scalingo. | `string` | n/a | yes |
+| <a name="input_notifiers"></a> [notifiers](#input\_notifiers) | List of notification channels (email, slack, webhook, rocket\_chat) for the application. | <pre>list(object({<br/>    name            = string<br/>    platform        = string<br/>    active          = optional(bool, true)<br/>    send_all_events = optional(bool, false)<br/>    send_all_alerts = optional(bool, false)<br/>    selected_events = optional(set(string), [])<br/>    emails          = optional(list(string), [])<br/>    webhook_url     = optional(string, "")<br/>  }))</pre> | `[]` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of the Scalingo project to associate the application with. | `string` | `null` | no |
 | <a name="input_review_apps"></a> [review\_apps](#input\_review\_apps) | Configuration of the review apps of the application. | <pre>object({<br/>    enabled = optional(bool, false)<br/><br/>    # By default: delete review apps 0 hours after closing the PR<br/>    delete_on_close_enabled      = optional(bool, true)<br/>    hours_before_delete_on_close = optional(string, "0")<br/><br/>    # By default: delete review apps after 5 days of inactivity (= no new deployment)<br/>    delete_stale_enabled      = optional(bool, true)<br/>    hours_before_delete_stale = optional(string, "168")<br/><br/>    # By default: do not create review apps for PRs from forks<br/>    automatic_creation_from_forks_allowed = optional(bool, false)<br/>  })</pre> | `{}` | no |
 | <a name="input_router_logs"></a> [router\_logs](#input\_router\_logs) | When true, the router logs are included in the application logs. (default: `false`) | `bool` | `false` | no |
 | <a name="input_stack"></a> [stack](#input\_stack) | The stack to use for the app (default: "scalingo-22"). | `string` | `"scalingo-22"` | no |
@@ -91,6 +100,7 @@ Used in production by :
 |------|-------------|
 | <a name="output_all_environment_variables"></a> [all\_environment\_variables](#output\_all\_environment\_variables) | All environment variables of the Scalingo application (ones added by the terraform module and ones added by Scalingo add-ons). |
 | <a name="output_app_id"></a> [app\_id](#output\_app\_id) | ID of the Scalingo application. |
+| <a name="output_base_url"></a> [base\_url](#output\_base\_url) | Default URL of the Scalingo application (without canonical domain override). |
 | <a name="output_domain"></a> [domain](#output\_domain) | Hostname to use to access the application. Same as the `url` output but without the `https://`. |
 | <a name="output_git_url"></a> [git\_url](#output\_git\_url) | Hostname to use to deploy code with Git + SSH. |
 | <a name="output_origin_domain"></a> [origin\_domain](#output\_origin\_domain) | The FQDN of the Scalingo application (`<your_app_name>.<region>.scalingo.io`). Same as the `domain` output if you have not set a canonical domain. |


### PR DESCRIPTION
## Summary
- Regenerate the `<!-- BEGIN_TF_DOCS -->` block with terraform-docs v0.19.0 (the version documented in the README)
- The block was stale: provider requirement still showed `~> 2.2`, and the inputs/resources/outputs added since were missing (`hds_resource`, `letsencrypt`, `limited_collaborators`, `notifiers`, `alerts`, `project_id`, `base_url` output)

## Test plan
- [x] `terraform-docs markdown table --output-mode inject .` produces no further diff
- [x] Generated tables match the current variables.tf/outputs.tf

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYz235RSa89PRbTwsVttVm

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYz235RSa89PRbTwsVttVm)_